### PR TITLE
bimbo mode allow long words to end in punctuation

### DIFF
--- a/key-intercept/bimbo.test.ts
+++ b/key-intercept/bimbo.test.ts
@@ -76,3 +76,11 @@ test("applyBimbo_MAXWORDLENGTH_AFTER", () => {
 test("applyBimbo_MAXWORDLENGTH", () => {
     expect(applyBimbo("testword", new Date(9999, 1), 4, false)).toBe("teuhhhh long words harddd hehe");
 });
+
+test("applyBimbo_MAXWORDLENGTH_EXCLUDEPUNCTUATIONATEND", () => {
+    expect(applyBimbo("test!", new Date(9999, 1), 4, false)).toBe("test!");
+});
+
+test("applyBimbo_MAXWORDLENGTH_MIDDLEPUNCTUATION", () => {
+    expect(applyBimbo("te!st", new Date(9999, 1), 4, false)).toBe("teuhhhh long words harddd hehe");
+});

--- a/key-intercept/index.ts
+++ b/key-intercept/index.ts
@@ -290,7 +290,7 @@ export function applyBimbo(msg: string, bimbo_end: Date, bimbo_word_length: numb
                 changed = true;
                 if (verbose) { console.log("pronoun found, added 'like totally'"); }
             }
-            if (word.length > maxWordLength && word.replace(/[^\W]+$/, "").length > maxWordLength) {
+            if (word.length > maxWordLength && word.replace(/\W+$/, "").length > maxWordLength) {
                 if (verbose) { console.log("word: " + word + " was too long"); }
                 output += word.substring(0, maxWordLength - 2);
                 output += "uhhhh long words harddd hehe";

--- a/key-intercept/index.ts
+++ b/key-intercept/index.ts
@@ -290,7 +290,7 @@ export function applyBimbo(msg: string, bimbo_end: Date, bimbo_word_length: numb
                 changed = true;
                 if (verbose) { console.log("pronoun found, added 'like totally'"); }
             }
-            if (word.replace(/[!?.,;:]+$/, "").length > maxWordLength) {
+            if (word.replace(/\W+$/, "").length > maxWordLength) {
                 if (verbose) { console.log("word: " + word + " was too long"); }
                 output += word.substring(0, maxWordLength - 2);
                 output += "uhhhh long words harddd hehe";

--- a/key-intercept/index.ts
+++ b/key-intercept/index.ts
@@ -290,7 +290,7 @@ export function applyBimbo(msg: string, bimbo_end: Date, bimbo_word_length: numb
                 changed = true;
                 if (verbose) { console.log("pronoun found, added 'like totally'"); }
             }
-            if (word.length > maxWordLength) {
+            if (word.replace(/[!?.,;:]+$/, "").length > maxWordLength) {
                 if (verbose) { console.log("word: " + word + " was too long"); }
                 output += word.substring(0, maxWordLength - 2);
                 output += "uhhhh long words harddd hehe";

--- a/key-intercept/index.ts
+++ b/key-intercept/index.ts
@@ -290,7 +290,7 @@ export function applyBimbo(msg: string, bimbo_end: Date, bimbo_word_length: numb
                 changed = true;
                 if (verbose) { console.log("pronoun found, added 'like totally'"); }
             }
-            if (word.replace(/\W+$/, "").length > maxWordLength) {
+            if (word.length > maxWordLength && word.replace(/[^\W]+$/, "").length > maxWordLength) {
                 if (verbose) { console.log("word: " + word + " was too long"); }
                 output += word.substring(0, maxWordLength - 2);
                 output += "uhhhh long words harddd hehe";


### PR DESCRIPTION
https://github.com/Key-Intercept/key-intercept/issues/13

just using a regex to trim none word characters `test100%!` becomes `test100`